### PR TITLE
Refactor auth and DB initialization to fix TypeError

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -1,10 +1,7 @@
 const jwt = require('jsonwebtoken');
-const path = require('path');
-const sqlite3 = require('sqlite3').verbose();
+const db = require('./database'); // Import the shared db instance
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-const dbPath = path.resolve(__dirname, 'database.db');
-const db = new sqlite3.Database(dbPath);
 
 // JWT Authentication Middleware
 const authenticateToken = (req, res, next) => {
@@ -58,4 +55,4 @@ const authorize = (requiredPermissions) => {
   };
 };
 
-module.exports = { authenticateToken, authorize, db };
+module.exports = { authenticateToken, authorize };

--- a/backend/database.js
+++ b/backend/database.js
@@ -1,0 +1,16 @@
+// backend/database.js
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const dbPath = path.resolve(__dirname, 'database.db');
+
+const db = new sqlite3.Database(dbPath, (err) => {
+  if (err) {
+    console.error('Error opening database from database.js', err.message);
+    // It's crucial to handle this error properly. Exiting or throwing might be appropriate
+    // depending on how critical the DB is at startup. For now, just logging.
+  } else {
+    console.log('Connected to the SQLite database via database.js.');
+  }
+});
+
+module.exports = db;

--- a/backend/routes/experiments.js
+++ b/backend/routes/experiments.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // POST /api/experiments - Create a new experiment
 router.post('/experiments', authenticateToken, authorize(['manage_experiments']), (req, res) => {

--- a/backend/routes/instruments.js
+++ b/backend/routes/instruments.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // POST /api/instruments - Create Instrument
 router.post('/', authenticateToken, authorize(['manage_instruments']), (req, res) => {
@@ -149,7 +150,7 @@ router.post('/:instrumentId/usage-logs', authenticateToken, authorize(['log_inst
   const { instrumentId } = req.params;
   const { start_time, end_time, notes } = req.body;
   // user_id should be taken from the authenticated user token
-  const userId = req.user.id;
+  const userId = req.user.userId; // Corrected to use userId from JWT payload
 
   if (!start_time) {
     return res.status(400).json({ message: 'Start time is required.' });

--- a/backend/routes/reagent_orders.js
+++ b/backend/routes/reagent_orders.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // Helper function for ISO8601 date validation (YYYY-MM-DD)
 const isValidDate = (dateString) => {

--- a/backend/routes/reagents.js
+++ b/backend/routes/reagents.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth'); // Updated import for authenticateToken and authorize
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // Helper function for ISO8601 date validation (YYYY-MM-DD)
 const isValidDate = (dateString) => {

--- a/backend/routes/sample_tests.js
+++ b/backend/routes/sample_tests.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // Placeholder for routes
 

--- a/backend/routes/samples.js
+++ b/backend/routes/samples.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // Placeholder success response for non-implemented routes
 const placeholderHandler = (req, res) => {

--- a/backend/routes/suppliers.js
+++ b/backend/routes/suppliers.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // POST /api/suppliers - Add a new supplier
 router.post('/', authenticateToken, authorize(['manage_inventory']), (req, res) => {

--- a/backend/routes/tests.js
+++ b/backend/routes/tests.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { db, authenticateToken, authorize } = require('../auth');
+const { authenticateToken, authorize } = require('../auth');
+const db = require('../database'); // Import shared db instance
 
 // POST /api/tests - Create a new test
 router.post('/tests', authenticateToken, authorize(['manage_tests']), (req, res) => {


### PR DESCRIPTION
- Centralized database initialization in `backend/database.js`.
- Centralized authentication middleware (`authenticateToken`, `authorize`) in `backend/auth.js`, using the shared DB instance.
- Updated `backend/index.js` and all route files in `backend/routes/` to use the singleton DB and auth functions.
- This resolves a `TypeError: authorize is not a function` in `experiments.js` likely caused by duplicated initializations or circular dependencies.
- Corrected usage of `req.user.userId` (was `req.user.id`) in `instruments.js`.
- Removed duplicate definitions of auth middleware and DB connections.